### PR TITLE
added validation that only filters filteredObject in global state con…

### DIFF
--- a/src/context/GlobalStateContext.tsx
+++ b/src/context/GlobalStateContext.tsx
@@ -27,7 +27,7 @@ export type ActionType =
 function reducer(state: StateType, action: ActionType): StateType {
   if (action.type === 'filters') {
     const filteredObject = Object.fromEntries(
-      Object.entries(action.payload).filter(([key, value]) => key && value),
+      Object.entries(action.payload).filter(([key, value]) => key && value !== undefined),
     )
     return { ...state, ...filteredObject }
   } else {


### PR DESCRIPTION
## 📖 Description
Right now it seems we update `filteredObject` inside the reducer of `src\context\GlobalStateContext.tsx` such that we only keep the keys that have values of that `action.payload` object.

So for example, if `action.payload` looks like this

```
{
  business_focus: undefined,
  business_line: undefined,
  business_market: undefined,
  business_size: undefined,
  cs_degree: undefined,
  gender: undefined,
  include_relocated: true,
  include_remote_abroad: undefined,
  level: undefined,
  salary: 12312,
  title: ['frontend'],
  yoe_from_included: undefined,
  yoe_to_excluded: undefined
}
```

it becomes

```
{
    "include_relocated": true,
    "title": [
        "frontend"
    ],
    "salary": 12312
}
```

thereby removing all undefined values in the object, problem however, is that the condition `key && value` isn't appropriate as this will also remove the keys whose value are false (which is exactly our problem when a user sets one of those checkboxes to false) just basically unticking the box. simply adding the `!== undefined` asserts that the removed keys, are those whose value is undefined

This PR solves this issue: https://github.com/egytech-fyi/egytech-fyi/issues/13

## 🔄 Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?
This small change was tested locally aswell as when I have built the project

## 🚧 Affected Parts:
The files affected are
`src\context\GlobalStateContext.tsx`

## 📋 Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
