### PR TITLE
Feature/contribute to GitHub tag

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,10 @@
-import { MailOutlined, BellOutlined, PlusCircleOutlined, TeamOutlined } from '@ant-design/icons'
+import {
+  MailOutlined,
+  BellOutlined,
+  PlusCircleOutlined,
+  TeamOutlined,
+  GithubOutlined,
+} from '@ant-design/icons'
 import '@styles/Footer.styles.scss'
 
 const FooterNotes = () => {
@@ -47,7 +53,11 @@ const FooterActions = () => {
         href='https://docs.google.com/forms/d/e/1FAIpQLSfBAjjgs14SQ9i3Dgo6BDPp-m7sxqHaUt4kFOghV-44knIUPg/viewform'
         target='_blank'>
         <PlusCircleOutlined />
-        Contribute
+        Participate
+      </a>
+      <a href='https://github.com/egytech-fyi' target='_blank'>
+        <GithubOutlined />
+        Collaborate
       </a>
       <a
         href='https://docs.google.com/forms/d/e/1FAIpQLSfKS-ZBzixfgOlsqpMEmn65_Em1Ek1-wOLXfhrXHORP9gsp0g/viewform?usp=sf_link'

--- a/src/styles/Footer.styles.scss
+++ b/src/styles/Footer.styles.scss
@@ -18,7 +18,7 @@
 }
 
 .footer-actions {
-    max-width: 900px;
+    max-width: 700px;
     margin: 0 auto;
     color: var(--accent-color);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react-swc';
-import path from 'path';
-
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import path from 'path'
 
 export default defineConfig({
   resolve: {
@@ -20,4 +19,4 @@ export default defineConfig({
     },
   },
   plugins: [react()],
-});
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,23 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@assets': path.resolve(new URL('./src/assets', import.meta.url).pathname),
-      '@components': path.resolve(new URL('./src/components', import.meta.url).pathname),
-      '@constants': path.resolve(new URL('./src/constants', import.meta.url).pathname),
-      '@context': path.resolve(new URL('./src/context', import.meta.url).pathname),
-      '@functions': path.resolve(new URL('./src/functions', import.meta.url).pathname),
-      '@mock': path.resolve(new URL('./src/mock', import.meta.url).pathname),
-      '@pages': path.resolve(new URL('./src/pages', import.meta.url).pathname),
-      '@services': path.resolve(new URL('./src/services', import.meta.url).pathname),
-      '@styles': path.resolve(new URL('./src/styles', import.meta.url).pathname),
-      '@types': path.resolve(new URL('./src/types', import.meta.url).pathname),
-      '@utils': path.resolve(new URL('./src/utils', import.meta.url).pathname),
+      '@assets': path.resolve(__dirname, 'src/assets'),
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@constants': path.resolve(__dirname, 'src/constants'),
+      '@context': path.resolve(__dirname, 'src/context'),
+      '@functions': path.resolve(__dirname, 'src/functions'),
+      '@mock': path.resolve(__dirname, 'src/mock'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@services': path.resolve(__dirname, 'src/services'),
+      '@styles': path.resolve(__dirname, 'src/styles'),
+      '@types': path.resolve(__dirname, 'src/types'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
     },
   },
   plugins: [react()],
-})
+});


### PR DESCRIPTION
## 📖 Description
- I added a new tag to the footer with the name `Collaborate`  and a GitHub icon. 
also, I update the word `Contribute` to `Participate` to not confuse the user. Between Contribute to GitHub and participate in the salary form. 
- I changed the width of the footer by 200px since I added a new action because it was overlapping with the 
overflow slide in the right this is going to be responsive in this issue https://github.com/egytech-fyi/egytech-fyi/issues/12

- I had an issue while running the project locally, I did step by step what was there in the MD file, but I got an error related to 
vite.config.ts 
the error I had was.
![image](https://github.com/egytech-fyi/egytech-fyi/assets/16765061/7dc1146e-8add-42fa-961a-0ab4f6cd4d7b)

how I fixed?

instead of `
      '@assets': path.resolve(new URL('./src/assets', import.meta.url).pathname)` 
 I used     
  ` '@assets': path.resolve(__dirname, 'src/assets')`




## 🔄 Change Type

- [x] New feature (non-breaking change which adds functionality)

##  📸 Screenshot 
![image](https://github.com/egytech-fyi/egytech-fyi/assets/16765061/65fd2b89-f274-4e3e-8b87-3d7d51d7bb97)

## 🧪 How Has This Been Tested?
I tested this feature locally, as you can see in the screenshot. 

## 🚧 Affected Parts:
The `footer` component 

## 📋 Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
