### PR TITLE
Add loading state to insights page (/report)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,20 @@
 import { BrowserRouter as Router, Route, Routes as Switch } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { Layout } from 'antd'
+import { Layout, Spin } from 'antd'
 import { Footer, Navbar } from '@components'
 import { GlobalStateProvider } from '@context'
-import { LandingPage, Compensation, Insights } from '@pages'
+import { LandingPage, Compensation } from '@pages'
 import '@styles/App.styles.scss'
-import { useState } from 'react'
+import { Suspense, lazy, useState } from 'react'
 import Highcharts from 'highcharts'
 import HighchartsAccessibility from 'highcharts/modules/accessibility'
 
 // Initialize the accessibility module
 HighchartsAccessibility(Highcharts)
+
+const Insights = lazy(() =>
+  import('./pages/Insights').then((module) => ({ default: module.Insights })),
+)
 
 const { Content } = Layout
 
@@ -41,14 +45,16 @@ function App() {
           <Navbar handleOpenDrawer={showDrawer} />
           <Content>
             <div className='app-container'>
-              <Switch>
-                <Route path='/' element={<LandingPage />} />
-                <Route
-                  path='/report'
-                  element={<Insights drawerOpen={visible} onDrawerClose={handleCloseDrawer} />}
-                />
-                <Route path='/dashboard' element={<Compensation />} />
-              </Switch>
+              <Suspense fallback={<Spin size='large' style={{ margin: 'auto' }} />}>
+                <Switch>
+                  <Route path='/' element={<LandingPage />} />
+                  <Route
+                    path='/report'
+                    element={<Insights drawerOpen={visible} onDrawerClose={handleCloseDrawer} />}
+                  />
+                  <Route path='/dashboard' element={<Compensation />} />
+                </Switch>
+              </Suspense>
               <Footer />
             </div>
           </Content>

--- a/src/pages/Insights.tsx
+++ b/src/pages/Insights.tsx
@@ -1,6 +1,7 @@
-import { Anchor, Col, Divider, Drawer, Row } from 'antd'
+import { Anchor, Col, Divider, Drawer, Row, Spin } from 'antd'
 import { Overview, Satisfaction, Technology } from '@pages'
 import '@styles/Insights.styles.scss'
+import { useEffect, useState } from 'react'
 
 interface AnchorItem {
   key: string
@@ -112,6 +113,14 @@ const anchorItems: AnchorItem[] = [
 ]
 
 export const Insights = ({ drawerOpen, onDrawerClose }: InsightsProps) => {
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    setIsLoading(false)
+  }, [])
+
+  if (isLoading) return <Spin size='large' style={{ margin: 'auto' }} />
+
   return (
     <div className='insights-page'>
       <Row>

--- a/src/styles/Footer.styles.scss
+++ b/src/styles/Footer.styles.scss
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     gap: 32px;
+    margin-top: auto;
 }
 
 .footer-note {

--- a/src/styles/Insights.styles.scss
+++ b/src/styles/Insights.styles.scss
@@ -1,4 +1,5 @@
 .insights-page {
+    min-height: calc(100vh - 64px);
     padding: 2.5rem 0;
 }
 


### PR DESCRIPTION
# 📖 Description

**I had some issues while I was trying to squash the commits on the previous PR ( #36 ) so I decided to open a new one instead.**

I've noticed that by using `React.lazy` it shows the loading state for the first time only, so I managed the loading state inside the `Insights` component itself.

Also, I kept the lazy loading for the insights page as I noticed that it reduced the initial load of the website:
```
// Without lazy loading

✓ 3227 modules transformed.
dist/index.html                          2.32 kB │ gzip:   1.00 kB
dist/assets/crying-cat-DyOghE35.png     24.45 kB
dist/assets/index-UoKFwPRL.css           8.68 kB │ gzip:   2.42 kB
dist/assets/index-CvP9iYiR.js        1,485.66 kB │ gzip: 483.68 kB

// With lazy loading

✓ 3228 modules transformed.
dist/index.html                          2.32 kB │ gzip:   1.00 kB
dist/assets/crying-cat-DyOghE35.png     24.45 kB
dist/assets/index-BoZBcBe4.css           8.78 kB │ gzip:   2.46 kB
dist/assets/Insights-BiAKm3QZ.js        42.88 kB │ gzip:  12.37 kB
dist/assets/index-Bn_PyZJ2.js        1,444.04 kB │ gzip: 473.05 kB
```

but I don't know if this has a meaningful impact on the performance, if not we can remove it and just use the loading state inside the component itself.

Let me know what you think.


## 🔄 Change Type

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

Check the mentioned PR

## 🚧 Affected Parts
Insights page (/report)

## 📋 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
