### PR TITLE
Fixed hiding-span position on firefox

### DIFF
--- a/src/styles/SharedComponents.styles.scss
+++ b/src/styles/SharedComponents.styles.scss
@@ -65,7 +65,7 @@
 .hiding-span {
   display: block;
   position: absolute;
-  top: calc(48.5% - -1px);
+  top: calc(48% - -1px);
   width: calc(100% + 4px);
   background: white;
   height: 1px;


### PR DESCRIPTION


# 📖 Description

Fixed hiding-span position on firefox on pc. (Have a look at the screenshots below)

## 🔄 Change Type

- [✅ ] Bug fix (non-breaking change which fixes an issue)

## 📷 Screenshots

![after](https://github.com/user-attachments/assets/9e56cc36-b2f4-4c88-b18a-eb6c6b6068df)
![before](https://github.com/user-attachments/assets/a1c02f30-a04c-42f7-870d-77cdace704e6)


## 🧪 How Has This Been Tested?

I tested the new value and made sure it works for chrome and firefox on both pc and phones.

## 🚧 Affected Parts

Input fields of the dashboard.

## 📋 Checklist

- [ ✅] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my own code
- [ ✅] My changes generate no new warnings
- [✅ ] New and existing unit tests pass locally with my changes
- [ ✅] Any dependent changes have been merged and published in downstream modules
